### PR TITLE
Fix case-sensitivity typo

### DIFF
--- a/packages/ember-autoresize/lib/mixins/autoresize.js
+++ b/packages/ember-autoresize/lib/mixins/autoresize.js
@@ -150,7 +150,7 @@ Ember.AutoResize = Ember.Mixin.create(/** @scope Ember.AutoResize.prototype */{
 
     @method scheduleMeasurement
    */
-  scheduleMeasurement: Ember.observer('autoresizeText', function () {
+  scheduleMeasurement: Ember.observer('autoResizeText', function () {
     if (this.get('autoresize')) {
       Ember.run.once(this, 'measureSize');
     }


### PR DESCRIPTION
Typo prevented scheduleMeasurement from firing properly, at least on newer ember versions.
