### PR TITLE
Add runloop to font load promise resolution

### DIFF
--- a/addon/system/font-loaded.js
+++ b/addon/system/font-loaded.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import adobeBlank from './adobe-blank';
 import { measureText } from "dom-ruler";
 
-const { RSVP } = Ember;
+const { RSVP, run } = Ember;
 
 var sheet;
 function injectAdobeBlank() {
@@ -67,7 +67,7 @@ export default function (fontFamily, options={ timeout: 3000 }) {
 
   if (loadedFonts[fontFamily] == null) {
     loadedFonts[fontFamily] = new RSVP.Promise(function (resolve, reject) {
-      checkIfFontLoaded(fontFamily, Ember.copy(options, true), resolve, reject);
+      checkIfFontLoaded(fontFamily, Ember.copy(options, true), run.bind(resolve), run.bind(reject));
     });
   }
 


### PR DESCRIPTION
Without this runloop, an autorun is incurred. This damages performance and make it difficult to write tests using ember-autoresize.

Fixed here.