### PR TITLE
add autoResizeText to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ Set the maximum number of rows for the element.  Recommended for textareas.
 {{textarea autoresize=true max-rows=10}}
 ```
 
+#### autoResizeText
+
+Optimistically resize the height of the textarea so when users reach the end of a line, they will be presented with space to begin typing. Defaults to `true`.
+
+```handlebars
+{{textarea autoresize=true autoResizeText=false}}
+```
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
This behavior confused me and I initially thought it was a bug. It was easy to fix after looking in the source code and it might be helpful for others to bring this up to the README.

Thanks for creating the addon! ✌️ 
