### PR TITLE
Guard measureSize to prevent call if el isDestroyed

### DIFF
--- a/addon/mixins/autoresize.js
+++ b/addon/mixins/autoresize.js
@@ -170,7 +170,7 @@ export default Ember.Mixin.create(/** @scope AutoResize.prototype */{
     @method scheduleMeasurement
    */
   scheduleMeasurement: on('init', observer('autoResizeText', function () {
-    if (get(this, 'autoresize')) {
+    if (get(this, 'autoresize') && !get(this, 'isDestroyed')) {
       once(this, 'measureSize');
     }
   })),


### PR DESCRIPTION
This fixes an issue that we are experiencing when running our integration tests on Ember 2.10. The error output is `Uncaught Error: Assertion Failed: calling set on destroyed object`. It's kind of weird that this has just cropped up as an issue as we weren't experiencing it before but this still seems like a sensible guard to have in place in any case. 