### PR TITLE
Support config option to skip custom font loading

### DIFF
--- a/addon/mixins/autoresize.js
+++ b/addon/mixins/autoresize.js
@@ -7,6 +7,7 @@ import { observer, computed, set, get } from '@ember/object';
 import { on } from '@ember/object/evented';
 import { getStyles, getLayout, measureText } from "dom-ruler";
 import fontLoaded from "../system/font-loaded";
+import config from 'ember-get-config';
 
 // jQuery is not loaded in fastboot
 let trim = function(str) {
@@ -199,6 +200,10 @@ export default Mixin.create({
     @method fontFamilyLoaded
    */
   fontFamilyLoaded: observer('autoresizeElement', function () {
+    if (!this._loadCustomFont()) {
+      return;
+    }
+
     let styles = getStyles(get(this, 'autoresizeElement'));
     let fontFamilies = styles.fontFamily.split(',');
     A(fontFamilies).forEach((fontFamily) => {
@@ -360,5 +365,13 @@ export default Mixin.create({
         element.style[prop] = styles[prop];
       }
     }
-  }
+  },
+
+  /**
+    Internal function to read config options
+  */
+  _loadCustomFont() {
+    return get(config || {}, 'ember-autoresize.customFont') !== false;
+  },
+
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -3581,6 +3581,16 @@
         "ember-cli-babel": "6.11.0"
       }
     },
+    "ember-get-config": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/ember-get-config/-/ember-get-config-0.2.4.tgz",
+      "integrity": "sha1-EYSSoqA9c+RgBO13eSiUICH+Hs0=",
+      "dev": true,
+      "requires": {
+        "broccoli-file-creator": "1.1.1",
+        "ember-cli-babel": "6.11.0"
+      }
+    },
     "ember-load-initializers": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ember-load-initializers/-/ember-load-initializers-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "ember-cli-uglify": "^2.0.0",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
+    "ember-get-config": "^0.2.4",
     "ember-load-initializers": "^1.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-native-dom-event-dispatcher": "^0.6.3",

--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -1,11 +1,11 @@
-const browsers = [
+var browsers = [
   'last 1 Chrome versions',
   'last 1 Firefox versions',
   'last 1 Safari versions'
 ];
 
-const isCI = !!process.env.CI;
-const isProduction = process.env.EMBER_ENV === 'production';
+var isCI = !!process.env.CI;
+var isProduction = process.env.EMBER_ENV === 'production';
 
 if (isCI || isProduction) {
   browsers.push('ie 11');


### PR DESCRIPTION
This is my attempt at avoiding the custom font loading overhead.  Hopefully resolving Issue #41 

In `config/environment.js`
```
'ember-autoresize': {
   customFont: false
}
```