### PR TITLE
Move ember-get-config to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-autoresize",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1471,7 +1471,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/broccoli-file-creator/-/broccoli-file-creator-1.1.1.tgz",
       "integrity": "sha1-GzW2fSFavfrdjUnutpSTw55sNFA=",
-      "dev": true,
       "requires": {
         "broccoli-kitchen-sink-helpers": "0.2.9",
         "broccoli-plugin": "1.3.0",
@@ -1485,7 +1484,6 @@
           "version": "0.2.9",
           "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
           "integrity": "sha1-peCYbtjXb7WYS2jD8EUNOpbjbsw=",
-          "dev": true,
           "requires": {
             "glob": "5.0.15",
             "mkdirp": "0.5.1"
@@ -1495,7 +1493,6 @@
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
           "requires": {
             "inflight": "1.0.6",
             "inherits": "2.0.3",
@@ -1507,8 +1504,7 @@
         "rsvp": {
           "version": "3.0.21",
           "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.21.tgz",
-          "integrity": "sha1-ScWI/hjvKTvNCrn05nVuasQzNZ8=",
-          "dev": true
+          "integrity": "sha1-ScWI/hjvKTvNCrn05nVuasQzNZ8="
         }
       }
     },
@@ -1921,7 +1917,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/broccoli-writer/-/broccoli-writer-0.1.1.tgz",
       "integrity": "sha1-1NcaqPKvvGejhmuRotp5CEuWqy0=",
-      "dev": true,
       "requires": {
         "quick-temp": "0.1.8",
         "rsvp": "3.6.2"
@@ -3585,7 +3580,6 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/ember-get-config/-/ember-get-config-0.2.4.tgz",
       "integrity": "sha1-EYSSoqA9c+RgBO13eSiUICH+Hs0=",
-      "dev": true,
       "requires": {
         "broccoli-file-creator": "1.1.1",
         "ember-cli-babel": "6.11.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "dependencies": {
     "dom-ruler": "^0.2.5",
     "ember-cli-babel": "^6.6.0",
-    "ember-cli-version-checker": "^2.1.0"
+    "ember-cli-version-checker": "^2.1.0",
+    "ember-get-config": "^0.2.4"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
@@ -47,7 +48,6 @@
     "ember-cli-uglify": "^2.0.0",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
-    "ember-get-config": "^0.2.4",
     "ember-load-initializers": "^1.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-native-dom-event-dispatcher": "^0.6.3",


### PR DESCRIPTION
Didn't realize this needed to be under dependencies.  I already had it included in my other apps and didn't notice until I used it in an app that didn't have it as a dependency.

Follow on to #88 